### PR TITLE
Price tracker contract for average sales prices for collections (initially only supports Legions)

### DIFF
--- a/contracts/TreasureMarketplace.sol
+++ b/contracts/TreasureMarketplace.sol
@@ -97,6 +97,9 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
     /// @notice Indicates if bid related functions are active.
     bool public areBidsActive;
 
+    /// @notice Address of the contract that tracks sales and prices of collections.
+    address public salesTrackerAddress;
+
     /// @notice The fee portion was updated
     /// @param  fee new fee amount (in units of basis points)
     event UpdateFee(uint256 fee);
@@ -114,6 +117,7 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
     /// @notice The fee recipient was updated
     /// @param  feeRecipient the new recipient to get fees
     event UpdateFeeRecipient(address feeRecipient);
+
 
     /// @notice The approval status for a token was updated
     /// @param  nft    which token contract was updated
@@ -221,6 +225,10 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
         uint128 pricePerItem,
         address paymentToken
     );
+    
+    /// @notice The sales tracker contract was update
+    /// @param  _salesTrackerAddress the new address to call for sales price tracking
+    event UpdateSalesTracker(address _salesTrackerAddress);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {}
@@ -659,6 +667,10 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
         } else {
             listings[_buyItemParams.nftAddress][_buyItemParams.tokenId][_buyItemParams.owner].quantity -= _buyItemParams.quantity;
         }
+        
+        if(salesTrackerAddress != address(0)) {
+            
+        }
 
         if(_buyItemParams.usingEth) {
             return _buyItemParams.quantity * listedItem.pricePerItem;
@@ -787,6 +799,15 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
         require(address(weth) == address(0), "WETH address already set");
 
         weth = IERC20Upgradeable(_wethAddress);
+    }
+
+    /// @notice Updates the fee recipient which receives fees during sales
+    /// @dev    This is callable only by the owner.
+    /// @param  _salesTrackerAddress the wallet to receive fees
+    function setSalesTracker(address _salesTrackerAddress) public onlyRole(TREASURE_MARKETPLACE_ADMIN_ROLE) {
+        require(_salesTrackerAddress != address(0), "TreasureMarketplace: cannot set 0x0 address");
+        salesTrackerAddress = _salesTrackerAddress;
+        emit UpdateSalesTracker(_salesTrackerAddress);
     }
 
     function toggleAreBidsActive() external onlyRole(TREASURE_MARKETPLACE_ADMIN_ROLE) {

--- a/contracts/TreasureMarketplace.sol
+++ b/contracts/TreasureMarketplace.sol
@@ -806,7 +806,7 @@ contract TreasureMarketplace is AccessControlEnumerableUpgradeable, PausableUpgr
     /// @notice Updates the fee recipient which receives fees during sales
     /// @dev    This is callable only by the owner.
     /// @param  _priceTrackerAddress the wallet to receive fees
-    function setSalesTracker(address _priceTrackerAddress) public onlyRole(TREASURE_MARKETPLACE_ADMIN_ROLE) {
+    function setPriceTracker(address _priceTrackerAddress) public onlyRole(TREASURE_MARKETPLACE_ADMIN_ROLE) {
         require(_priceTrackerAddress != address(0), "TreasureMarketplace: cannot set 0x0 address");
         priceTrackerAddress = _priceTrackerAddress;
         emit UpdateSalesTracker(_priceTrackerAddress);

--- a/contracts/TreasureNFTPriceTracker.sol
+++ b/contracts/TreasureNFTPriceTracker.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PRBMathUD60x18} from "@prb/math/contracts/PRBMathUD60x18.sol";
+
+import {ITreasureNFTPriceTracker, FloorType} from "./interfaces/ITreasureNFTPriceTracker.sol";
+import {ILegionMetadataStore, LegionGeneration, LegionRarity} from "./interfaces/ILegionMetadataStore.sol";
+
+contract TreasureNFTPriceTracker is ITreasureNFTPriceTracker, OwnableUpgradeable {
+    using PRBMathUD60x18 for uint256;
+
+    address public treasureMarketplaceContract;
+    address public legionContract;
+    address public legionMetadata;
+
+    mapping(address => mapping(FloorType => uint256)) internal collectionToFloorTypeToPriceAvg;
+
+    /// @notice Perform initial contract setup
+    /// @dev    The initializer modifier ensures this is only called once, the owner should confirm this was properly
+    ///         performed before publishing this contract address.
+    /// @param  _treasureMarketplaceContract address of treasure marketplace
+    /// @param  _legionContract address of the legion collection
+    function initialize(
+        address _treasureMarketplaceContract,
+        address _legionContract,
+        address _legionMetadata
+    )
+        external
+        initializer
+    {
+        require(address(_treasureMarketplaceContract) != address(0), "TreasureNFTPricing: cannot set address(0)");
+        require(address(_legionContract) != address(0), "TreasureNFTPricing: cannot set address(0)");
+
+        treasureMarketplaceContract = _treasureMarketplaceContract;
+        legionContract = _legionContract;
+        legionMetadata = _legionMetadata;
+    }
+
+    /// @notice Record sale price and update floor pricing averages
+    /// @dev    If an average does not yet exist, the new average will be _salePrice
+    ///         avg will be stored as FloorType.FLOOR unless special sub-floor criteria is met
+    /// @param _collection Address of the collection that had a token sale
+    /// @param _tokenId The token sold
+    /// @param _salePrice The amount the sale was for
+    function recordSale(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _salePrice
+    ) external {
+        require(msg.sender == treasureMarketplaceContract, "Invalid caller");
+        if(_collection != legionContract) {
+            return;
+        }
+        (LegionGeneration gen,LegionRarity rarity) = ILegionMetadataStore(legionMetadata).genAndRarityForLegion(_tokenId);
+        if(gen != LegionGeneration.GENESIS) {
+            return;
+        }
+        FloorType floorType;
+        if(rarity == LegionRarity.COMMON) {
+            floorType = FloorType.SUBFLOOR1;
+        } else if(rarity == LegionRarity.UNCOMMON) {
+            floorType = FloorType.SUBFLOOR2;
+        } else if(rarity == LegionRarity.RARE) {
+            floorType = FloorType.SUBFLOOR3;
+        }
+        else {
+            return;
+        }
+        uint256 oldAverage = collectionToFloorTypeToPriceAvg[legionContract][floorType];
+        uint256 newAverage;
+        if(oldAverage == 0) {
+            newAverage = _salePrice;
+        } else {
+            newAverage = PRBMathUD60x18.avg(oldAverage, _salePrice);
+        }
+        collectionToFloorTypeToPriceAvg[legionContract][floorType] = newAverage;
+
+        emit AveragePriceUpdated(
+            legionContract,
+            floorType,
+            oldAverage,
+            _salePrice,
+            newAverage
+        );
+    }
+
+    /// @notice Return the current floor average for a given collection
+    /// @dev    Provide a floor type to receive a recorded sub-floor average
+    ///         Collections not containing subfloor records should be queried with FloorType.FLOOR
+    /// @param  _collection address of collection to get floor price average of
+    /// @param  _floorType the sub-floor average of the given collection
+    function getAveragePriceForCollection(address _collection, FloorType _floorType) external view returns (uint256) {
+        return collectionToFloorTypeToPriceAvg[_collection][_floorType];
+    }
+}

--- a/contracts/interfaces/ILegionMetadataStore.sol
+++ b/contracts/interfaces/ILegionMetadataStore.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+interface ILegionMetadataStore {
+    // Returns the generation and rarity for the given legion.
+    function genAndRarityForLegion(uint256 _tokenId) external view returns(LegionGeneration, LegionRarity);
+}
+
+enum LegionRarity {
+    LEGENDARY,
+    RARE,
+    SPECIAL,
+    UNCOMMON,
+    COMMON,
+    RECRUIT
+}
+
+enum LegionGeneration {
+    GENESIS,
+    AUXILIARY,
+    RECRUIT
+}

--- a/contracts/interfaces/ITreasureNFTPriceTracker.sol
+++ b/contracts/interfaces/ITreasureNFTPriceTracker.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+interface ITreasureNFTPriceTracker {
+    event AveragePriceUpdated(
+        address indexed _collection,
+        FloorType indexed _floorType,
+        uint256 _oldAverage,
+        uint256 _salePrice,
+        uint256 _newAverage
+    );
+
+    // Saves the given sale of a token in a collection if it meets the saving criteria.
+    function recordSale(address _collection, uint256 _tokenId, uint256 _salePrice) external;
+    // Returns the average price for the given collection in the floor type category.
+    // Can return 0 if asking for a FloorType that isn't being tracked for that given collection
+    function getAveragePriceForCollection(address _collection, FloorType _floorType) external view returns (uint256);
+}
+
+// Allows for customization within tracking floor prices
+// Ex: Tracking legion genesis commons could be subfloor1, genesis uncommons subfloor2, etc
+enum FloorType {
+    FLOOR,
+    SUBFLOOR1,
+    SUBFLOOR2,
+    SUBFLOOR3
+}

--- a/contracts/mock/LegionMetadataStoreMock.sol
+++ b/contracts/mock/LegionMetadataStoreMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+import {ILegionMetadataStore, LegionGeneration, LegionRarity} from "../interfaces/ILegionMetadataStore.sol";
+
+contract LegionMetadataStoreMock is ILegionMetadataStore {
+
+    LegionGeneration internal gen;
+    LegionRarity internal rarity;
+
+    constructor(LegionGeneration _gen, LegionRarity _rarity) {
+        gen = _gen;
+        rarity = _rarity;
+    }
+
+    function genAndRarityForLegion(uint256) external view returns(LegionGeneration gen_, LegionRarity rarity_) {
+        gen_ = gen;
+        rarity_ = rarity;
+    }
+}

--- a/test/TreasureMarketplace.test.ts
+++ b/test/TreasureMarketplace.test.ts
@@ -123,6 +123,18 @@ describe('TreasureMarketplace', function () {
                 .to.be.equal(500);
         });
 
+        it('setSalesTracker()', async function () {
+            const salesTrackerAddress = staker3;
+
+            await expect(marketplace.connect(staker3Signer).setSalesTracker(salesTrackerAddress))
+                .to.be.revertedWith("AccessControl: account 0x90f79bf6eb2c4f870365e785982e1f101e93b906 is missing role 0x34d5e892b0a7ec1561fc4a5fdcb31b798cf623590906b938d356c9619e539958");
+
+            await expect(marketplace.setSalesTracker(salesTrackerAddress))
+                .to.emit(marketplace, "UpdateSalesTracker")
+                .withArgs(salesTrackerAddress);
+            expect(await marketplace.salesTrackerAddress()).to.be.equal(salesTrackerAddress);
+        });
+
         it('approve token', async function () {
             expect(await marketplace.tokenApprovals(nft.address)).to.equal(TOKEN_APPROVAL_STATUS_NOT_APPROVED);
             await marketplace.setTokenApprovalStatus(nft.address, TOKEN_APPROVAL_STATUS_ERC_721_APPROVED, magicToken.address);

--- a/test/TreasureMarketplace.test.ts
+++ b/test/TreasureMarketplace.test.ts
@@ -123,13 +123,13 @@ describe('TreasureMarketplace', function () {
                 .to.be.equal(500);
         });
 
-        it('setSalesTracker()', async function () {
+        it('setPriceTracker()', async function () {
             const salesTrackerAddress = staker3;
 
-            await expect(marketplace.connect(staker3Signer).setSalesTracker(salesTrackerAddress))
+            await expect(marketplace.connect(staker3Signer).setPriceTracker(salesTrackerAddress))
                 .to.be.revertedWith("AccessControl: account 0x90f79bf6eb2c4f870365e785982e1f101e93b906 is missing role 0x34d5e892b0a7ec1561fc4a5fdcb31b798cf623590906b938d356c9619e539958");
 
-            await expect(marketplace.setSalesTracker(salesTrackerAddress))
+            await expect(marketplace.setPriceTracker(salesTrackerAddress))
                 .to.emit(marketplace, "UpdateSalesTracker")
                 .withArgs(salesTrackerAddress);
             expect(await marketplace.salesTrackerAddress()).to.be.equal(salesTrackerAddress);

--- a/test/TreasureNFTPriceTracker.test.ts
+++ b/test/TreasureNFTPriceTracker.test.ts
@@ -1,0 +1,106 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import { getCurrentTime, mineBlock } from './utils';
+
+const { ethers, deployments, artifacts, getNamedAccounts } = hre;
+const { deploy } = deployments;
+
+enum LegionRarity {
+    LEGENDARY,
+    RARE,
+    SPECIAL,
+    UNCOMMON,
+    COMMON,
+    RECRUIT
+}
+
+enum LegionGeneration {
+    GENESIS,
+    AUXILIARY,
+    RECRUIT
+}
+
+enum FloorType {
+    FLOOR,
+    SUBFLOOR1,
+    SUBFLOOR2,
+    SUBFLOOR3
+}
+
+describe('TreasureNFTPriceTracker', function () {
+    let _nftPriceTracker: any;
+    let _genCommonMetadataContract: any;
+    
+    let _legionNFTContractAddress: string;
+
+    let _marketplaceSigner: any;
+    let _randomSigner: any;
+
+    before(async function () {
+        const namedAccounts = await getNamedAccounts();
+
+        _marketplaceSigner = ethers.provider.getSigner(namedAccounts.staker1);
+        _randomSigner = ethers.provider.getSigner(namedAccounts.staker2);
+
+        _legionNFTContractAddress = namedAccounts.staker3;
+    });
+
+    beforeEach(async function () {
+        const metadataMockFactory = await ethers.getContractFactory('LegionMetadataStoreMock')
+        _genCommonMetadataContract = await metadataMockFactory.deploy(LegionGeneration.GENESIS, LegionRarity.COMMON);
+        await _genCommonMetadataContract.deployed();
+
+        const trackerFactory = await ethers.getContractFactory('TreasureNFTPriceTracker');
+        _nftPriceTracker = await trackerFactory.deploy()
+        await _nftPriceTracker.deployed();
+        await _nftPriceTracker.initialize(_marketplaceSigner._address, _legionNFTContractAddress, _genCommonMetadataContract.address);
+    });
+
+    it('initialize()', async function () {
+        await expect(_nftPriceTracker.initialize(_marketplaceSigner._address, _legionNFTContractAddress, _genCommonMetadataContract.address))
+            .to.be.revertedWith("Initializable: contract is already initialized");
+        
+        expect(await _nftPriceTracker.treasureMarketplaceContract())
+            .to.equal(_marketplaceSigner._address);
+        expect(await _nftPriceTracker.legionContract())
+            .to.equal(_legionNFTContractAddress);
+        expect(await _nftPriceTracker.legionMetadata())
+            .to.equal(_genCommonMetadataContract.address);
+    });
+
+    it('recordSale()', async function () {
+        const tokenId = 1;
+        const salePrice1 = ethers.utils.parseEther('500');
+        const salePrice2 = ethers.utils.parseEther('100');
+        const salePrice3 = ethers.utils.parseEther('900');
+        await expect(_nftPriceTracker.recordSale(_legionNFTContractAddress, tokenId, salePrice1))
+            .to.be.revertedWith("Invalid caller");
+
+        // AveragePriceUpdated(
+        //     address indexed _collection,
+        //     FloorType indexed _floorType,
+        //     uint256 _oldAverage,
+        //     uint256 _salePrice,
+        //     uint256 _newAverage
+        // )
+        await expect(_nftPriceTracker.connect(_marketplaceSigner).recordSale(_legionNFTContractAddress, tokenId, salePrice1))
+            .to.emit(_nftPriceTracker, 'AveragePriceUpdated')
+            .withArgs(_legionNFTContractAddress, FloorType.SUBFLOOR1, 0, salePrice1, salePrice1);
+        
+        const expectedAvgPrice = salePrice1.add(salePrice2).div(2);
+        await expect(_nftPriceTracker.connect(_marketplaceSigner).recordSale(_legionNFTContractAddress, tokenId, salePrice2))
+            .to.emit(_nftPriceTracker, 'AveragePriceUpdated')
+            .withArgs(_legionNFTContractAddress, FloorType.SUBFLOOR1, salePrice1, salePrice2, expectedAvgPrice);
+
+        expect(await _nftPriceTracker.getAveragePriceForCollection(_legionNFTContractAddress, FloorType.SUBFLOOR1))
+            .to.equal(expectedAvgPrice);
+        
+        const expectedAvgPrice2 = expectedAvgPrice.add(salePrice3).div(2);
+        await expect(_nftPriceTracker.connect(_marketplaceSigner).recordSale(_legionNFTContractAddress, tokenId, salePrice3))
+            .to.emit(_nftPriceTracker, 'AveragePriceUpdated')
+            .withArgs(_legionNFTContractAddress, FloorType.SUBFLOOR1, expectedAvgPrice, salePrice3, expectedAvgPrice2);
+
+            expect(await _nftPriceTracker.getAveragePriceForCollection(_legionNFTContractAddress, FloorType.SUBFLOOR1))
+                .to.equal(expectedAvgPrice2);
+    });
+});


### PR DESCRIPTION
Price tracker is a contract who's sole purpose initially is to track Legion genesis common/uncommon/rare average sales price (requested by Defrag)

TreasureMarketplace changes:
- Added setPriceTracker function guarded by AccessControl to set the address of the price tracker contract to be invoked
- when buying an item, invoke recordSales with the sales information

TreasureNFTPricingTracker:
- initialize with treasure marketplace contract/legion contract/legion metadata contract
- recordSales can only be invoked by the treasure marketplace contract
- recordSales kicks out if the sale isn't a Legion, if the Legion isn't a genesis, or if the Legion isn't common/uncommon/rare
- recordSales currently only saves Legion Genesis sales into 3 different tracked buckets (common, uncommon, rare)
- recordSales emits an AveragePriceUpdated event when a new average is calculated and stored.