### PR TITLE
deployment script for treasure mainnet

### DIFF
--- a/.upgradable/unknown-network-978658.json
+++ b/.upgradable/unknown-network-978658.json
@@ -9,12 +9,422 @@
       "address": "0x41c47A0C27d4254BA43e72C602E94587f57fe2ad",
       "txHash": "0x23a2299468388504f6be23a5bfca70727f9cef5c8ae0da6ea38f9325fd193330",
       "kind": "transparent"
+    },
+    {
+      "address": "0x2037ADe36b4bF2bc813590702FaBaBBee5e6f4fC",
+      "txHash": "0x035eb5b1d74441f4068d44b30e7b6f8b0c42afeeb3136a202dca5db84ce5ae61",
+      "kind": "transparent"
     }
   ],
   "impls": {
     "d4471d8e595c07afc0368407b86fba8a0db8c17f8404fcecf954afd9f9f9acba": {
       "address": "0xF6471F3A836cBCA989697e98B1e5879c22661127",
       "txHash": "0x10bae59867a7ec1697b0af203a371c938b3d61452c614cd6d967755a280d4ec8",
+      "layout": {
+        "solcVersion": "0.8.12",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
+          },
+          {
+            "label": "_roleMembers",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)4069_storage)",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "paymentToken",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_contract(IERC20Upgradeable)2316",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:67"
+          },
+          {
+            "label": "fee",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:70"
+          },
+          {
+            "label": "feeReceipient",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_address",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:73"
+          },
+          {
+            "label": "listings",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(ListingOrBid)14994_storage)))",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:76"
+          },
+          {
+            "label": "tokenApprovals",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_mapping(t_address,t_enum(TokenApprovalStatus)15005)",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:79"
+          },
+          {
+            "label": "feeWithCollectionOwner",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:82"
+          },
+          {
+            "label": "collectionToCollectionOwnerFee",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_mapping(t_address,t_struct(CollectionOwnerFee)15001_storage)",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:85"
+          },
+          {
+            "label": "collectionToPaymentToken",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:88"
+          },
+          {
+            "label": "weth",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_contract(IERC20Upgradeable)2316",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:91"
+          },
+          {
+            "label": "tokenBids",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(ListingOrBid)14994_storage)))",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:94"
+          },
+          {
+            "label": "collectionBids",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_struct(ListingOrBid)14994_storage))",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:97"
+          },
+          {
+            "label": "areBidsActive",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:100"
+          },
+          {
+            "label": "priceTrackerAddress",
+            "offset": 1,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "TreasureMarketplaceTestnet",
+            "src": "contracts/TreasureMarketplaceTestnet.sol:103"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)2316": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_enum(TokenApprovalStatus)15005": {
+            "label": "enum TreasureMarketplaceTestnet.TokenApprovalStatus",
+            "members": [
+              "NOT_APPROVED",
+              "ERC_721_APPROVED",
+              "ERC_1155_APPROVED"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_enum(TokenApprovalStatus)15005)": {
+            "label": "mapping(address => enum TreasureMarketplaceTestnet.TokenApprovalStatus)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_struct(ListingOrBid)14994_storage))": {
+            "label": "mapping(address => mapping(address => struct TreasureMarketplaceTestnet.ListingOrBid))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(ListingOrBid)14994_storage)))": {
+            "label": "mapping(address => mapping(uint256 => mapping(address => struct TreasureMarketplaceTestnet.ListingOrBid)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(CollectionOwnerFee)15001_storage)": {
+            "label": "mapping(address => struct TreasureMarketplaceTestnet.CollectionOwnerFee)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ListingOrBid)14994_storage)": {
+            "label": "mapping(address => struct TreasureMarketplaceTestnet.ListingOrBid)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)4069_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(ListingOrBid)14994_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct TreasureMarketplaceTestnet.ListingOrBid))",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)4069_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3768_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CollectionOwnerFee)15001_storage": {
+            "label": "struct TreasureMarketplaceTestnet.CollectionOwnerFee",
+            "members": [
+              {
+                "label": "fee",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "recipient",
+                "type": "t_address",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ListingOrBid)14994_storage": {
+            "label": "struct TreasureMarketplaceTestnet.ListingOrBid",
+            "members": [
+              {
+                "label": "quantity",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "pricePerItem",
+                "type": "t_uint128",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "expirationTime",
+                "type": "t_uint64",
+                "offset": 24,
+                "slot": "0"
+              },
+              {
+                "label": "paymentTokenAddress",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3768_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "e6f10772614a13b7f65242ebee7dc3601fdcecac87dda31989de7f5d29f459d5": {
+      "address": "0x7A3A3b88551920d957F6b6e999541eD26d80e005",
+      "txHash": "0x472e455ab80fcf23d15cb6c10818bd23e3141c2b49ddfb4ec56a6de922ca5d1a",
       "layout": {
         "solcVersion": "0.8.12",
         "storage": [

--- a/deploy/treasureMainnet/TreasureMarketplace.deploy.ts
+++ b/deploy/treasureMainnet/TreasureMarketplace.deploy.ts
@@ -11,6 +11,7 @@ const func = async () => {
     // Constants for this deploy script.
     const fee = 500n; // 5%
     const feeWithCollectionOwner = 250n; // 2.5%
+    // TODO: Set the feeReceipient to the multisig address when deployed
     const feeReceipient = deployer.zkWallet.address;
     const newOwner = deployer.zkWallet.address;
     const magicAddress = '0x263D8f36Bb8d0d9526255E205868C26690b04B88';

--- a/deploy/treasureMainnet/TreasureMarketplace.deploy.ts
+++ b/deploy/treasureMainnet/TreasureMarketplace.deploy.ts
@@ -1,0 +1,114 @@
+import * as hre from 'hardhat';
+import { HttpNetworkUserConfig } from 'hardhat/types';
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Provider, Wallet } from 'zksync-ethers';
+
+const func = async () => {
+    const wallet = getWallet();
+
+    const deployer = new Deployer(hre, wallet);
+
+    // Constants for this deploy script.
+    const fee = 500n; // 5%
+    const feeWithCollectionOwner = 250n; // 2.5%
+    const feeReceipient = deployer.zkWallet.address;
+    const newOwner = deployer.zkWallet.address;
+    const magicAddress = '0x263D8f36Bb8d0d9526255E205868C26690b04B88';
+    const wethAddress = '0x263D8f36Bb8d0d9526255E205868C26690b04B88';
+
+    const contractName = 'TreasureMarketplace';
+
+    const contract = await deployer.loadArtifact(contractName);
+    const marketplace = await hre.zkUpgrades.deployProxy(
+        deployer.zkWallet,
+        contract,
+        [fee, feeReceipient, magicAddress],
+        {
+            initializer: 'initialize',
+        },
+    );
+    await marketplace.waitForDeployment();
+
+    // Set the WETH address in the marketplace contracted if needed.
+    const wethAddressFromContract = await marketplace.weth();
+    if (wethAddress.toLowerCase() !== wethAddressFromContract.toLowerCase()) {
+        await marketplace.setWeth(wethAddress);
+    }
+
+    // Set the DAO fees (w/o and w/ collection owner) in the contract.
+    const feeFromContract = await marketplace.fee();
+    const feeWithCollectionOwnerFromContract = await marketplace.feeWithCollectionOwner();
+    if (feeFromContract !== fee || feeWithCollectionOwnerFromContract !== feeWithCollectionOwner) {
+        await marketplace.setFee(fee, feeWithCollectionOwner);
+    }
+
+    const areBidsActive = await marketplace.areBidsActive();
+    if (!areBidsActive) {
+        await marketplace.toggleAreBidsActive();
+    }
+
+    // Grep the admin role identifier.
+    const TREASURE_MARKETPLACE_ADMIN_ROLE = await marketplace.TREASURE_MARKETPLACE_ADMIN_ROLE();
+    // If newOwner is not an admin, grant admin role to newOwner.
+    if (!(await marketplace.hasRole(TREASURE_MARKETPLACE_ADMIN_ROLE, newOwner))) {
+        await marketplace.grantRole(TREASURE_MARKETPLACE_ADMIN_ROLE, newOwner);
+    }
+
+    const defaultProxyAdmin = await hre.zkUpgrades.admin.getInstance(wallet);
+
+    const entries = [
+        { name: 'TreasureMarketplace.address', value: marketplace.getAddress() },
+        { name: 'DefaultProxyAdmin.address', value: await defaultProxyAdmin.getAddress() },
+        {
+            name: 'DefaultProxyAdmin.getProxyAdmin("TreasureMarketplace")',
+            value: await defaultProxyAdmin.getProxyAdmin(await marketplace.getAddress()),
+        },
+        { name: 'DefaultProxyAdmin.owner()', value: await defaultProxyAdmin.owner() },
+        {
+            name: `TreasureMarketplace.hasRole(${newOwner})`,
+            value: await marketplace.hasRole(TREASURE_MARKETPLACE_ADMIN_ROLE, newOwner),
+        },
+        {
+            name: `TreasureMarketplace.hasRole(${deployer})`,
+            value: await marketplace.hasRole(TREASURE_MARKETPLACE_ADMIN_ROLE, deployer.zkWallet.address),
+        },
+        {
+            name: `TreasureMarketplace.feeReceipient()`,
+            value: await marketplace.feeReceipient(),
+        },
+        { name: `TreasureMarketplace.fee()`, value: await marketplace.fee() },
+        {
+            name: 'TreasureMarketplace.areBidsActive()',
+            value: await marketplace.areBidsActive(),
+        },
+        { name: 'MAGIC address', value: await marketplace.paymentToken() },
+        { name: 'WETH address', value: await marketplace.weth() },
+    ];
+
+    console.log(`---- TreasureMarketplace Config ----`);
+    console.table(entries);
+};
+
+export const getProvider = () => {
+    const rpcUrl = (hre.network.config as HttpNetworkUserConfig).url;
+    if (!rpcUrl)
+        throw Error(
+            `⛔️ RPC URL wasn't found in "${hre.network.name}"! Please add a "url" field to the network config in hardhat.config.ts`,
+        );
+
+    // Initialize ZKsync Provider
+    const provider = new Provider(rpcUrl);
+
+    return provider;
+};
+
+export const getWallet = (privateKey?: string) => {
+    const provider = getProvider();
+
+    // Initialize ZKsync Wallet
+    const wallet = new Wallet(privateKey ?? process.env.WALLET_PRIVATE_KEY!, provider);
+
+    return wallet;
+};
+
+export default func;

--- a/deploy/treasureTopaz/TreasureMarketplaceTestnet.deploy.ts
+++ b/deploy/treasureTopaz/TreasureMarketplaceTestnet.deploy.ts
@@ -11,8 +11,8 @@ const func = async () => {
     // Constants for this deploy script.
     const fee = 500n; // 5%
     const feeWithCollectionOwner = 250n; // 2.5%
-    const feeReceipient = '0x892d81728eB3B33E463AEEdc2dC167130E74Be8c';
-    const newOwner = '0x892d81728eB3B33E463AEEdc2dC167130E74Be8c';
+    const feeReceipient = deployer.zkWallet.address;
+    const newOwner = deployer.zkWallet.address;
     const magicAddress = '0x095ded714d42cBD5fb2E84A0FfbFb140E38dC9E1';
     const wethAddress = '0x095ded714d42cBD5fb2E84A0FfbFb140E38dC9E1';
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -120,10 +120,19 @@ const config: HardhatUserConfig = {
             ethNetwork: 'sepolia',
             zksync: true,
             kmsKeyId: devKmsKey,
+            verifyURL: 'https://rpc-explorer-verify.topaz.treasure.lol/contract_verification',
+        },
+        treasureMainnet: {
+            url: 'https://rpc.treasure.lol',
+            ethNetwork: 'mainnet',
+            zksync: true,
+            kmsKeyId: prodKmsKey,
+            verifyURL: 'https://rpc-explorer-verify.treasure.lol/contract_verification',
+            saveDeployments: true,
         },
     },
     zksolc: {
-        version: 'latest',
+        version: '1.5.7',
         settings: {},
     },
     solidity: {


### PR DESCRIPTION
added deployment script for treasure mainnet 

### differences from testnet script

- owner set to deployer
- feerecipient set to deployer
- both magic and weth address set to the WMAGIC address
- removed `setPaymentToken` call